### PR TITLE
Do not filter relative paths

### DIFF
--- a/src/main/java/io/jenkins/plugins/prism/SourceDirectoryFilter.java
+++ b/src/main/java/io/jenkins/plugins/prism/SourceDirectoryFilter.java
@@ -19,8 +19,8 @@ import edu.hm.hafner.util.PathUtil;
 public class SourceDirectoryFilter {
     /**
      * Filters the specified collection of additional source code directories so that only permitted source directories
-     * will be returned. Permitted source directories are absolute paths that have been registered using {@link
-     * PrismConfiguration#setSourceDirectories(java.util.List)} or relative paths in the workspace.
+     * will be returned. Permitted source directories are absolute paths that have been registered using
+     * {@link PrismConfiguration#setSourceDirectories(java.util.List)} or relative paths in the workspace.
      *
      * @param workspacePath
      *         the path to the workspace containing the affected files
@@ -40,9 +40,10 @@ public class SourceDirectoryFilter {
         PathUtil pathUtil = new PathUtil();
         Set<String> filteredDirectories = new HashSet<>();
         for (String sourceDirectory : requestedSourceDirectories) {
-            if (StringUtils.isNotBlank(sourceDirectory) && !"-".equals(sourceDirectory)) {
-                String normalized = pathUtil.getAbsolutePath(sourceDirectory);
-                if (pathUtil.isAbsolute(normalized)) {
+            if (StringUtils.isNotBlank(sourceDirectory)
+                    && !"-".equals(sourceDirectory)) {
+                if (pathUtil.isAbsolute(sourceDirectory)) {
+                    String normalized = pathUtil.getAbsolutePath(sourceDirectory);
                     if (allowedSourceDirectories.contains(normalized)) { // add only registered absolute paths
                         filteredDirectories.add(normalized);
                     }
@@ -52,7 +53,7 @@ public class SourceDirectoryFilter {
                     }
                 }
                 else {
-                    filteredDirectories.add(pathUtil.createAbsolutePath(workspacePath, normalized)); // relative workspace paths are always ok
+                    filteredDirectories.add(pathUtil.createAbsolutePath(workspacePath, sourceDirectory)); // relative workspace paths are always ok
                 }
             }
         }

--- a/src/test/java/io/jenkins/plugins/prism/PrismConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/PrismConfigurationTest.java
@@ -55,6 +55,18 @@ class PrismConfigurationTest {
     }
 
     @Test
+    void shouldNotFilterRelativePaths() {
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+        Set<String> requested = new HashSet<>();
+        String relative = "src/main/java";
+        requested.add(relative);
+
+        Set<String> allowedDirectories = filter.getPermittedSourceDirectories(NORMALIZED, new HashSet<>(),
+                requested, new FilteredLog("Error"));
+        assertThat(allowedDirectories).contains(NORMALIZED + "/" + relative);
+    }
+
+    @Test
     void shouldSaveConfigurationIfFoldersAreAdded() {
         GlobalConfigurationFacade facade = mock(GlobalConfigurationFacade.class);
         PrismConfiguration configuration = new PrismConfiguration(facade, mock(JenkinsFacade.class));


### PR DESCRIPTION
Relative paths will get expanded to an absolute path in the workspace so it is safe to retain them in the list of allowed directories.
