### PR TITLE
Bump plugin util api to 2.20 to fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node
 node_modules
 target
 *.iml
+.idea
 .classpath
 .project
 .settings

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,16 @@
     </dependency>
   </dependencies>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>commons-text-api</artifactId>
+        <version>1.10.0-27.vb_fa_3896786a_7</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 
     <testcontainers.version>1.17.5</testcontainers.version>
     <jsoup.version>1.15.3</jsoup.version>
+    <plugin-util-api.version>2.20.0</plugin-util-api.version>
   </properties>
 
   <licenses>
@@ -46,6 +47,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -69,6 +71,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>${plugin-util-api.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
@@ -35,7 +35,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS
+    static final ArchRule ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS;
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;

--- a/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
@@ -4,7 +4,6 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import edu.hm.hafner.util.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
@@ -36,7 +35,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchRuleDefinition.fields().that().areAnnotatedWith(ArchTest.class).should().notBePublic();
+    ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS = ArchitectureRules.ONLY_PACKAGE_PRIVATE_ARCHITECTURE_TESTS
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;

--- a/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/PluginArchitectureTest.java
@@ -4,6 +4,7 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import edu.hm.hafner.util.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
@@ -35,7 +36,7 @@ class PluginArchitectureTest {
     static final ArchRule NO_FORBIDDEN_CLASSES_CALLED = ArchitectureRules.NO_FORBIDDEN_CLASSES_CALLED;
 
     @ArchTest
-    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchitectureRules.NO_PUBLIC_ARCHITECTURE_TESTS;
+    static final ArchRule NO_PUBLIC_ARCHITECTURE_TESTS = ArchRuleDefinition.fields().that().areAnnotatedWith(ArchTest.class).should().notBePublic();
 
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;


### PR DESCRIPTION
A field has been removed in `edu.hm.hafner.util.ArchitectureRules` in later versions of plugin-util-api causing compilation errors when run in PCT.

Related to https://github.com/jenkinsci/warnings-ng-plugin/pull/1425

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
