### PR TITLE
Do not filter absolute paths that are part of the workspace

### DIFF
--- a/src/test/java/io/jenkins/plugins/prism/PrismConfigurationTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/PrismConfigurationTest.java
@@ -51,19 +51,7 @@ class PrismConfigurationTest {
         assertThat(log.getErrorMessages()).isEmpty();
         assertThat(get(configuration, log, ABSOLUTE_NOT_EXISTING)).isEmpty();
         assertThat(log.getErrorMessages())
-                .anySatisfy(m -> assertThat(m).contains("Removing source directory '/Three'"));
-    }
-
-    @Test
-    void shouldNotFilterRelativePaths() {
-        SourceDirectoryFilter filter = new SourceDirectoryFilter();
-        Set<String> requested = new HashSet<>();
-        String relative = "src/main/java";
-        requested.add(relative);
-
-        Set<String> allowedDirectories = filter.getPermittedSourceDirectories(NORMALIZED, new HashSet<>(),
-                requested, new FilteredLog("Error"));
-        assertThat(allowedDirectories).contains(NORMALIZED + "/" + relative);
+                .anySatisfy(m -> assertThat(m).contains("Removing").contains("'/Three'"));
     }
 
     @Test
@@ -85,7 +73,7 @@ class PrismConfigurationTest {
         assertThat(log.getErrorMessages()).isEmpty();
         assertThat(get(configuration, log, ABSOLUTE_NOT_EXISTING)).isEmpty();
         assertThat(log.getErrorMessages())
-                .anySatisfy(m -> assertThat(m).contains("Removing source directory '/Three'"));
+                .anySatisfy(m -> assertThat(m).contains("Removing").contains("'/Three'"));
         assertThat(get(configuration, log, ABSOLUTE_NOT_EXISTING, FIRST)).containsExactly(FIRST);
 
         configuration.clearRepeatableProperties();

--- a/src/test/java/io/jenkins/plugins/prism/SourceDirectoryFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/SourceDirectoryFilterTest.java
@@ -1,0 +1,114 @@
+package io.jenkins.plugins.prism;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.PathUtil;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SourceDirectoryFilterTest {
+    private static final PathUtil PATH_UTIL = new PathUtil();
+    private static final String SUB_FOLDER = "sub-folder";
+    private static final Set<String> EMPTY = Collections.emptySet();
+
+    @TempDir
+    private Path workspace;
+    @TempDir
+    private Path otherFolder;
+    private final FilteredLog log = new FilteredLog("Error");
+
+    private String aboluteWorkspacePath() {
+        return PATH_UTIL.getAbsolutePath(workspace);
+    }
+
+    @Test
+    void shouldSkipEmptyRequest() {
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(), EMPTY, EMPTY, log);
+
+        assertThat(allowedDirectories).isEmpty();
+    }
+
+    @Test
+    void shouldSkipEmptyDirectories() {
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                EMPTY, Set.of(StringUtils.EMPTY, "-"), log);
+
+        assertThat(allowedDirectories).isEmpty();
+    }
+
+    @Test
+    void shouldNotFilterRelativePaths() {
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var relative = "src/main/java";
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                EMPTY, Set.of(relative), log);
+
+        assertThat(allowedDirectories).contains(aboluteWorkspacePath() + "/" + relative);
+    }
+
+    @Test
+    void shouldAllowAbsoluteWorkspacePath() {
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                EMPTY, Set.of(aboluteWorkspacePath()), log);
+
+        assertThat(allowedDirectories).isEmpty();
+    }
+
+    @Test
+    void shouldAllowAbsoluteWorkspaceChildren() throws IOException {
+        var subFolder = workspace.resolve(SUB_FOLDER);
+        Files.createDirectory(subFolder);
+
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                EMPTY, Set.of(PATH_UTIL.getAbsolutePath(subFolder)), log);
+
+        assertThat(allowedDirectories).containsExactly(SUB_FOLDER);
+    }
+
+    @Test
+    void shouldNotAllowOtherFolder() throws IOException {
+        var subFolder = workspace.resolve(SUB_FOLDER);
+        Files.createDirectory(subFolder);
+
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                EMPTY, Set.of(PATH_UTIL.getAbsolutePath(otherFolder)), log);
+
+        assertThat(allowedDirectories).isEmpty();
+        assertThat(log.getErrorMessages()).last().asString()
+                .contains("Removing non-workspace source directory",
+                        "it has not been approved in Jenkins' global configuration");
+    }
+
+    @Test
+    void shouldAllowPermittedFolder() throws IOException {
+        var subFolder = workspace.resolve(SUB_FOLDER);
+        Files.createDirectory(subFolder);
+
+        SourceDirectoryFilter filter = new SourceDirectoryFilter();
+
+        var approvedFolder = PATH_UTIL.getAbsolutePath(otherFolder);
+        var allowedDirectories = filter.getPermittedSourceDirectories(aboluteWorkspacePath(),
+                Set.of(approvedFolder), Set.of(approvedFolder), log);
+        assertThat(allowedDirectories).containsExactly(approvedFolder);
+    }
+}


### PR DESCRIPTION
The path filter should only filter non-approved absolute paths that are outside the current workspace. Paths in the workspace should be retained and should be converted to a relative path in the workspace.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/677
