### PR TITLE
Use frontend-maven-plugin configuration of parent POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>6.10.0</version>
+    <version>6.12.0</version>
     <relativePath />
   </parent>
 
@@ -25,9 +25,6 @@
 
     <testcontainers.version>1.19.0</testcontainers.version>
     <jsoup.version>1.16.1</jsoup.version>
-
-    <node.version>18.12.0</node.version>
-    <npm.version>8.19.4</npm.version>
 
   </properties>
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+git pull
+git push
+mvn -B clean release:prepare release:perform


### PR DESCRIPTION
NPM and Node versions are now derived from [analysis-pom](https://github.com/jenkinsci/analysis-pom-plugin/blob/master/pom.xml). `frontend-maven-plugin` configuration is now derived from [plugin-pom](https://github.com/jenkinsci/plugin-pom/blob/master/pom.xml).