### PR TITLE
[BEE-41200] Changed from .each to .forEach as per prototype JS docs

### DIFF
--- a/src/main/resources/io/jenkins/plugins/prism/SourceCodeViewModel/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/prism/SourceCodeViewModel/index.jelly
@@ -19,7 +19,7 @@
        * Scroll to the warning.
        */
       jQuery3.fn.scrollView = function () {
-        return this.each(function () {
+        return this.forEach(function () {
           jQuery3('html, body').animate({
             scrollTop: jQuery3(this).offset().top - (jQuery3(window).height() / 2)
           }, 1000);


### PR DESCRIPTION
Removal of Prototype JS as per the jenkins blogs in prism-api-plugin

Jira: https://cloudbees.atlassian.net/browse/BEE-41200

There was a usage of .each in the jquery return function in index.jelly file. Updated the .each with .forEach as per the recommendation in the blog. (https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/)

![image](https://github.com/jenkinsci/prism-api-plugin/assets/142486073/c34ba463-31a6-4b4a-8c6b-8ac82cfb15d5)

**Before changes in prism API**

![Prism_before_changes](https://github.com/jenkinsci/prism-api-plugin/assets/142486073/1a3ca59a-6634-4920-9ff0-4b3e7530ae92)


**After changes in prism API**

![image](https://github.com/jenkinsci/prism-api-plugin/assets/142486073/c3efeb86-2134-4fb6-848c-e2dc598cf13a)

After the changes, I don't find any discrepancy on scrolling view of the prism.js page. Able to view the prism details clearly when scrolling up and down without any issue as before.

![Prism_after_changes](https://github.com/jenkinsci/prism-api-plugin/assets/142486073/9487a15c-2cf6-4ea3-bf55-810519852fde)

Thank you