### PR TITLE
Fix theme loading

### DIFF
--- a/src/main/webapp/js/theme-loader.js
+++ b/src/main/webapp/js/theme-loader.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     head.insertAdjacentHTML(
       'beforeend',
-      `<link id="prism-active-theme" rel="stylesheet" href="${baseUrl}/${themeCss}" />`)
+      `<link id="prism-active-theme" rel="stylesheet" href="${baseUrl}${themeCss}" />`)
   }
 
   if (window.getThemeManagerProperty && window.isSystemRespectingTheme) {


### PR DESCRIPTION
Unsure why this didn't pop up earlier - was working fine whilst I was working on it using `mvn hpi:run` - now that its installed in a Jenkins instance it's breaking. There's an additional slash that's breaking theme loading now - this PR fixes that.

<img width="440" alt="Screenshot 2024-05-08 at 10 00 31" src="https://github.com/jenkinsci/prism-api-plugin/assets/43062514/6a8ec5b3-9c96-4c74-ac05-4336306d8766">

### Testing done

* Theme loading works

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
