### PR TITLE
[JENKINS-73505] When using a glob relativize the workspace path

### DIFF
--- a/src/main/java/io/jenkins/plugins/prism/SourceDirectoryFilter.java
+++ b/src/main/java/io/jenkins/plugins/prism/SourceDirectoryFilter.java
@@ -111,8 +111,9 @@ public class SourceDirectoryFilter {
         }
 
         try {
-            PathMatcherFileVisitor visitor = new PathMatcherFileVisitor(pattern);
-            Files.walkFileTree(Paths.get(directory), visitor);
+            var workspace = Paths.get(directory);
+            PathMatcherFileVisitor visitor = new PathMatcherFileVisitor(workspace, pattern);
+            Files.walkFileTree(workspace, visitor);
             return visitor.getMatches();
         }
         catch (IllegalArgumentException exception) {
@@ -132,12 +133,14 @@ public class SourceDirectoryFilter {
     }
 
     private static class PathMatcherFileVisitor extends SimpleFileVisitor<Path> {
+        private final Path workspace;
         private final PathMatcher pathMatcher;
         private final List<String> matches = new ArrayList<>();
 
-        PathMatcherFileVisitor(final String syntaxAndPattern) {
+        PathMatcherFileVisitor(final Path workspace, final String syntaxAndPattern) {
             super();
 
+            this.workspace = workspace;
             pathMatcher = FileSystems.getDefault().getPathMatcher(syntaxAndPattern);
         }
 
@@ -147,7 +150,7 @@ public class SourceDirectoryFilter {
 
         @Override
         public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
-            if (pathMatcher.matches(dir)) {
+            if (pathMatcher.matches(dir) || pathMatcher.matches(workspace.relativize(dir))) {
                 matches.add(PATH_UTIL.getAbsolutePath(dir));
             }
             return FileVisitResult.CONTINUE;

--- a/src/test/java/io/jenkins/plugins/prism/SourceDirectoryFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/prism/SourceDirectoryFilterTest.java
@@ -104,6 +104,12 @@ class SourceDirectoryFilterTest {
 
         assertThat(allowedDirectories).map(s -> StringUtils.substringAfterLast(s, "/"))
                 .containsExactlyInAnyOrder("ok-1", "ok-2", "ok-3");
+
+        var singleGlob = filter.getPermittedSourceDirectories(absoluteWorkspacePath(),
+                EMPTY, Set.of("glob:sub-folder/ok-*"), log);
+
+        assertThat(singleGlob).map(s -> StringUtils.substringAfterLast(s, "/"))
+                .containsExactlyInAnyOrder("ok-1", "ok-2", "ok-3");
     }
 
     @Test


### PR DESCRIPTION
When a glob does not use the `**` path expansion we should relativize the path within the workspace before trying to match. 

See [JENKINS-73505](https://issues.jenkins.io/browse/JENKINS-73505).