### PR TITLE
Fix invisible text in analysis detail when using the jenkins dark theme

### DIFF
--- a/src/main/webapp/css/custom-prism.css
+++ b/src/main/webapp/css/custom-prism.css
@@ -36,6 +36,8 @@ pre > code.highlight {
 }
 
 .analysis-detail {
+    background-color: var(--background);
+    color: var(--text-color);
     margin:0;
     white-space: normal;
     padding:10px;
@@ -48,11 +50,6 @@ pre > code.highlight {
     background: #FFF9C4;
     font-weight: normal;
     transition: background-color .2s ease;
-}
-
-.analysis-detail > p {
-    color: black;
-    background-color: white;
 }
 
 .analysis-detail > pre {

--- a/src/main/webapp/css/custom-prism.css
+++ b/src/main/webapp/css/custom-prism.css
@@ -50,6 +50,11 @@ pre > code.highlight {
     transition: background-color .2s ease;
 }
 
+.analysis-detail > p {
+    color: black;
+    background-color: white;
+}
+
 .analysis-detail > pre {
     padding: 9.5px;
     margin: 1em 0 10px;


### PR DESCRIPTION
When using the official Jenkins dark theme, the text in `analysis-detail` uses the text color from the theme (white), and the background from this repository, from the `analysis-warning` class (also white).  This change explicitly sets the colours to be the same as those used in the default theme (black text on white background).

I specifically noticed this when look at a checkstyle report.

![image](https://github.com/user-attachments/assets/87803d44-f0d6-4e11-aa25-330755d1cbb2)

### Testing done
Change tested in browser, with browser development tools:
![image](https://github.com/user-attachments/assets/e237b0b6-b192-4793-a385-774e8488e4d1)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or [Jira](https://issues.jenkins.io/browse/JENKINS-75389)
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
