### PR TITLE
Use BOM versions for all dependencies marked with a TODO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <!-- TODO: remove the version when a matching BOM is available -->
-      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -73,8 +71,6 @@
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
       <classifier>tests</classifier>
-      <!-- TODO: remove the version when a matching BOM is available -->
-      <version>6.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Jenkins BOM contains all correct versions again.