### PR TITLE
[JENKINS-76020] Resolve missing architecture rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
@@ -70,6 +71,7 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
+      <version>6.1165.v322e76215b_a_4</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/archunit/PluginArchitectureTest.java
@@ -4,7 +4,7 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 
-import edu.hm.hafner.util.ArchitectureRules;
+import edu.hm.hafner.archunit.ArchitectureRules;
 
 import io.jenkins.plugins.util.PluginArchitectureRules;
 


### PR DESCRIPTION
Bump the version of plugin-util to 6.1165.v322e76215b_a_4. This version contains the missing class again.